### PR TITLE
Fix PluginTemplateExtension compatibility with NetBox 4.3.0

### DIFF
--- a/netbox_interface_synchronization/template_content.py
+++ b/netbox_interface_synchronization/template_content.py
@@ -3,7 +3,7 @@ from dcim.models import Interface, InterfaceTemplate
 
 
 class DeviceViewExtension(PluginTemplateExtension):
-    model = "dcim.device"
+    models = ["dcim.device"]
 
     def buttons(self):
         """Implements a compare interfaces button at the top of the page"""


### PR DESCRIPTION
This PR updates the plugin to be compatible with NetBox 4.3.0:

- Replaces the deprecated `model = "dcim.device"` with `models = ["dcim.device"]` for correct registration of `PluginTemplateExtension`.

Prior to this fix, NetBox would incorrectly invoke the extension on unrelated object types, potentially causing runtime errors.

https://github.com/jasonyates/netbox-documents/pull/75
https://github.com/netbox-community/netbox/discussions/19378