### PR TITLE
Fix: Recalculate CounterCacheFields after bulk_create in component sy…

### DIFF
--- a/netbox_interface_synchronization/utils.py
+++ b/netbox_interface_synchronization/utils.py
@@ -6,6 +6,8 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.conf import settings
 
 config = settings.PLUGINS_CONFIG['netbox_interface_synchronization']
+from netbox.registry import registry
+from utilities.counters import update_counts
 
 
 def split(s):
@@ -108,6 +110,19 @@ def post_components(
             updated += 1
 
     created = len(ObjectType.objects.bulk_create(bulk_create))
+
+    # Bulk create bypasses model save signals used by CounterCacheField.
+    # Recalculate related cached counters for parent models (Device, etc.).
+    if created > 0:
+        try:
+            for field_name, counter_name in registry['counter_fields'].get(ObjectType, {}).items():
+                fk_field = ObjectType._meta.get_field(field_name)
+                parent_model = fk_field.related_model
+                related_query = fk_field.related_query_name()
+                update_counts(parent_model, counter_name, related_query)
+        except Exception:
+            # Be tolerant of missing registry entries or other issues
+            pass
 
     # Rename selected components
     fixed = 0


### PR DESCRIPTION
## Description:
- **Summary:** Ensure cached counters (e.g., `power_port_count`) are consistent after plugin-driven component sync. The sync previously used `bulk_create()` which bypasses `post_save` signals used by `CounterCacheField`. This change recalculates affected counter fields after `bulk_create()` to restore correct device counts.

- **What I changed:**
  - Updated utils.py:
    - Import `registry` and `update_counts`.
    - After `ObjectType.objects.bulk_create(bulk_create)`, call `update_counts()` for any registered counter fields associated with `ObjectType`. The call is tolerant of missing registry entries or errors.

- **Why:** `bulk_create()` does not emit model `post_save` signals, so NetBox's signal-based `CounterCacheField` handlers were not notified of new objects. Recalculating counters ensures `device.power_port_count` and other cached counters are accurate after sync.

- **Related PRs / context:**  
  - Fix originally introduced in PR #20 (switched to `full_clean()` + `save()` to ensure signals ran).  
  - Regression introduced in PR #21 (reintroduced `bulk_create` path).